### PR TITLE
parallel radiosity (visible) along time-steps

### DIFF
--- a/flux/compressed_form_factors.py
+++ b/flux/compressed_form_factors.py
@@ -303,6 +303,7 @@ class FormFactorBlockMatrix(CompressedFormFactorBlock,
 
     def _matmat(self, x):
         ys = []
+        n = x.shape[1]
         for i, row_block_inds in enumerate(self._row_block_inds):
             m = len(row_block_inds)
             terms = (
@@ -310,7 +311,7 @@ class FormFactorBlockMatrix(CompressedFormFactorBlock,
                 for j, J in enumerate(self._col_block_inds)
                 if not self._blocks[i, j].is_empty_leaf
             )
-            col_block = sum(terms, np.zeros((m, 1), dtype=self.dtype))
+            col_block = sum(terms, np.zeros((m, n), dtype=self.dtype))
             ys.append(col_block)
         try:
             return np.concatenate(ys)[self._row_rev_perm]

--- a/flux/compressed_form_factors.py
+++ b/flux/compressed_form_factors.py
@@ -494,6 +494,18 @@ class CompressedFormFactorMatrix(scipy.sparse.linalg.LinearOperator):
             return pickle.load(f)
 
     @classmethod
+    def assemble(cls, *args, **kwargs):
+        assert "tree_kind" in kwargs
+        tree_kind = kwargs['tree_kind']
+        del kwargs['tree_kind']
+        if tree_kind == 'quad':
+            return CompressedFormFactorMatrix(
+                *args, **kwargs, RootBlock=FormFactorQuadtreeBlock)
+        elif tree_kind == 'oct':
+            return CompressedFormFactorMatrix(
+                *args, **kwargs, RootBlock=FormFactorOctreeBlock)
+
+    @classmethod
     def assemble_using_quadtree(cls, *args, **kwargs):
         return CompressedFormFactorMatrix(
             *args, **kwargs, RootBlock=FormFactorQuadtreeBlock)

--- a/flux/compressed_form_factors.py
+++ b/flux/compressed_form_factors.py
@@ -8,6 +8,7 @@ import flux.linalg
 
 from flux.debug import DebugLinearOperator, IndentedPrinter
 from flux.form_factors import get_form_factor_block
+from flux.octree import get_octant_order
 from flux.quadtree import get_quadrant_order
 
 
@@ -432,8 +433,8 @@ class FormFactorOctreeBlock(FormFactor2dTreeBlock):
         P = shape_model.P
         PI = P[:] if I is None else P[I]
         PJ = P[:] if J is None else P[J]
-        self._row_block_inds = _octant_order(PI)
-        self._col_block_inds = _octant_order(PJ)
+        self._row_block_inds = get_octant_order(PI)
+        self._col_block_inds = get_octant_order(PJ)
 
 
 class FormFactorPartitionBlock(FormFactorBlockMatrix):

--- a/flux/model.py
+++ b/flux/model.py
@@ -1,19 +1,26 @@
 import numpy as np
 
-
 from scipy.constants import sigma # Stefan-Boltzmann constant
-
 
 from flux.solve import solve_radiosity
 
-
 def compute_steady_state_temp(FF, E, rho, emiss,
                               clamp=True, tol=np.finfo(np.float64).eps):
-    B = solve_radiosity(FF, E, rho)[0]
-    if clamp:
-        B = np.maximum(0, B)
-    Q = solve_radiosity(FF, FF@((1 - rho)*B))[0]
-    if clamp:
-        Q = np.maximum(0, Q)
-    T = (((1 - rho)*B + emiss*Q)/(emiss*sigma))**0.25
+
+    # solve "visible" section for all time-steps
+    B_arr = solve_radiosity(FF, E, rho)[0]
+    if len(B_arr.shape)==1:
+        B_arr = B_arr[:,np.newaxis]
+
+    # solve IR section for each time step sequentially
+    T = []
+    for B in B_arr.T:
+        if clamp:
+            B = np.maximum(0, B)
+        IR = FF@((1 - rho)*B)
+        Q = solve_radiosity(FF, IR)[0]
+        if clamp:
+            Q = np.maximum(0, Q)
+        T.append((((1 - rho)*B + emiss*Q)/(emiss*sigma))**0.25)
+
     return T

--- a/flux/octree.py
+++ b/flux/octree.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 def get_octant_order(X, bbox=None):
     if bbox is not None:
         (xmin, xmax), (ymin, ymax), (zmin, zmax) = bbox


### PR DESCRIPTION
Hi Sam,
I tested what we discussed about performing the radiosity matmul for several time-steps at the same time (stacked as E columns), and it works very well (even just on 8 CPUs, haven't tried on GPUs yet):
```
Processing with shape x=(49152, 1) = previous mode, 1 time-step at the time
iter-1 took 0.37346982955932617 seconds
--------------------------------
Processing with shape x=(49152, 500) = 500 time steps in parallel
iter-500 took 2.127103090286255 seconds = 0.0042542386054992675 s/it
```
Also, results look ok (after a bit of tweaking in the scripts). I attach my implementation, allowing for a speed-up of ~ a factor 2 (as only "visible" section steps are independent, as we discussed). Below one can notice that the "visible radiosity" calculation at line 16 takes a fraction of the time of the IR one (within time-steps loop).
```
Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
     9                                           @profile
    10                                           def compute_steady_state_temp(FF, E, rho, emiss,
    11                                                                         clamp=True, tol=np.finfo(np.float64).eps):
    12                                               
    16         1   14237585.0 14237585.0      5.6      B_arr = solve_radiosity(FF, E, rho)[0]
    32         1          2.0      2.0      0.0      T = []
    33        11         67.0      6.1      0.0      for B in B_arr.T:
    34        10          6.0      0.6      0.0          if clamp:
    35        10      38045.0   3804.5      0.0              B = np.maximum(0, B)
    36        10   29527126.0 2952712.6     11.7          IR = FF@((1 - rho)*B)
    37        10  208905750.0 20890575.0     82.5          Q = solve_radiosity(FF, IR)[0]
    38        10          8.0      0.8      0.0          if clamp:
    39        10      16335.0   1633.5      0.0              Q = np.maximum(0, Q)
    40        10     599089.0  59908.9      0.2          T.append((((1 - rho)*B + emiss*Q)/(emiss*sigma))**0.25)
    41                                           
    42         1          0.0      0.0      0.0      return T
```
(I still have to figure out how to create "clean PR" not including too many mods, sorry...)