### PR TITLE
Hemisphere example

### DIFF
--- a/examples/hemispherical_crater/README.md
+++ b/examples/hemispherical_crater/README.md
@@ -1,0 +1,9 @@
+# `hemispherical_crater`
+
+The steady state flux and temperature have an analytical solution in
+the case of a hemispherical crater, even in the presence of occlusion
+(see [Ingersoll et
+al. 1992](https://www.sciencedirect.com/science/article/pii/001910359290016Z)). We
+use this analytical solution to test the accuracy of our model. This
+example runs a variety of tests and collects the results into tables
+and figures.

--- a/examples/hemispherical_crater/collect_ingersoll_gt_stats.sh
+++ b/examples/hemispherical_crater/collect_ingersoll_gt_stats.sh
@@ -2,7 +2,7 @@
 
 mkdir -p stats/gt
 
-for p in {4..10}
+for p in {5..13}
 do
 	echo "p = $p"
 	OUTDIR="stats/gt/ingersoll_p$p"

--- a/examples/hemispherical_crater/collect_ingersoll_gt_stats.sh
+++ b/examples/hemispherical_crater/collect_ingersoll_gt_stats.sh
@@ -2,7 +2,7 @@
 
 mkdir -p stats/gt
 
-for p in {11..12}
+for p in {4..10}
 do
 	echo "p = $p"
 	OUTDIR="stats/gt/ingersoll_p$p"

--- a/examples/hemispherical_crater/collect_ingersoll_stats.sh
+++ b/examples/hemispherical_crater/collect_ingersoll_stats.sh
@@ -4,7 +4,7 @@ TOL=$1
 
 mkdir -p stats/eps_$TOL
 
-for p in {4..10}
+for p in {5..13}
 do
 	echo "p = $p"
 	OUTDIR="stats/eps_$TOL/ingersoll_p$p"

--- a/examples/hemispherical_crater/collect_ingersoll_stats.sh
+++ b/examples/hemispherical_crater/collect_ingersoll_stats.sh
@@ -4,7 +4,7 @@ TOL=$1
 
 mkdir -p stats/eps_$TOL
 
-for p in {3..12}
+for p in {4..10}
 do
 	echo "p = $p"
 	OUTDIR="stats/eps_$TOL/ingersoll_p$p"

--- a/examples/hemispherical_crater/ingersoll.py
+++ b/examples/hemispherical_crater/ingersoll.py
@@ -45,11 +45,12 @@ import scipy.sparse
 import trimesh
 
 from flux.compressed_form_factors import CompressedFormFactorMatrix
+from flux.compressed_form_factors import FormFactorPartitionBlock
 from flux.form_factors import get_form_factor_matrix
 from flux.ingersoll import HemisphericalCrater
 from flux.model import compute_steady_state_temp
 from flux.plot import plot_blocks, tripcolor_vector
-from flux.shape import TrimeshShapeModel, get_surface_normals
+from flux.shape import CgalTrimeshShapeModel, get_surface_normals
 from flux.solve import solve_radiosity
 from flux.util import tic, toc
 
@@ -77,7 +78,7 @@ if __name__ == '__main__':
     N[N[:, 2] < 0] *= -1
 
     # Create a shape model from the triangle mesh (used for raytracing)
-    shape_model = TrimeshShapeModel(V, F, N)
+    shape_model = CgalTrimeshShapeModel(V, F, N)
 
     if args.tol is None:
         print("- tol argument not passed: assembling sparse form factor matrix")
@@ -87,8 +88,9 @@ if __name__ == '__main__':
         FF_nbytes = FF.data.nbytes + FF.indptr.nbytes + FF.indices.nbytes
     else:
         tic()
-        FF = CompressedFormFactorMatrix.assemble_using_partition(
-            shape_model, parts, tol=args.tol)
+        FF = CompressedFormFactorMatrix(
+            shape_model, parts=parts, tol=args.tol,
+            RootBlock=FormFactorPartitionBlock)
         t_FF = toc()
         FF_nbytes = FF.nbytes
     print('- finished assembly (%1.1f Mb) [%1.2f s]' %

--- a/examples/hemispherical_crater/make_paper_plots.py
+++ b/examples/hemispherical_crater/make_paper_plots.py
@@ -6,6 +6,8 @@ import matplotlib
 import matplotlib.pyplot as plt
 import os
 
+SAVE_PDF_PLOTS = False
+
 def load_stats(path):
     with open(path, 'r') as f:
         return json.load(f)
@@ -32,7 +34,7 @@ def get_values_by_key(dicts, key):
     return lst
 
 stats_gt_path = 'stats/gt'
-stats_path = 'stats/eps_1e-7'
+stats_path = 'stats/eps_1e-2'
 
 ################################################################################
 # MAKE INGERSOLL PLOTS
@@ -59,7 +61,8 @@ plt.legend()
 plt.xlabel('$h$')
 plt.ylabel('RMS error in $T$ (shadow)')
 plt.tight_layout()
-plt.savefig('paper_plots/h_vs_rms.pdf', dpi=dpi)
+if SAVE_PDF_PLOTS:
+    plt.savefig('paper_plots/h_vs_rms.pdf', dpi=dpi)
 plt.savefig('paper_plots/h_vs_rms.png', dpi=dpi)
 plt.close()
 
@@ -74,7 +77,8 @@ plt.legend()
 plt.xlabel('$h$')
 plt.ylabel('Size of $F$ [MB]')
 plt.tight_layout()
-plt.savefig('paper_plots/h_vs_size.pdf', dpi=dpi)
+if SAVE_PDF_PLOTS:
+    plt.savefig('paper_plots/h_vs_size.pdf', dpi=dpi)
 plt.savefig('paper_plots/h_vs_size.png', dpi=dpi)
 plt.close()
 
@@ -89,7 +93,8 @@ plt.legend()
 plt.xlabel('$h$')
 plt.ylabel('Time to compute $T$ [s]')
 plt.tight_layout()
-plt.savefig('paper_plots/h_vs_T_time.pdf', dpi=dpi)
+if SAVE_PDF_PLOTS:
+    plt.savefig('paper_plots/h_vs_T_time.pdf', dpi=dpi)
 plt.savefig('paper_plots/h_vs_T_time.png', dpi=dpi)
 plt.close()
 
@@ -110,7 +115,8 @@ plt.legend()
 plt.xlabel('$h$')
 plt.ylabel('Time to compute $B$ [s]')
 plt.tight_layout()
-plt.savefig('paper_plots/h_vs_B_and_E_time.pdf', dpi=dpi)
+if SAVE_PDF_PLOTS:
+    plt.savefig('paper_plots/h_vs_B_and_E_time.pdf', dpi=dpi)
 plt.savefig('paper_plots/h_vs_B_and_E_time.png', dpi=dpi)
 plt.close()
 
@@ -125,6 +131,7 @@ plt.legend()
 plt.xlabel('$h$')
 plt.ylabel('Time to assemble $F$ [s]')
 plt.tight_layout()
-plt.savefig('paper_plots/h_vs_assembly_time.pdf', dpi=dpi)
+if SAVE_PDF_PLOTS:
+    plt.savefig('paper_plots/h_vs_assembly_time.pdf', dpi=dpi)
 plt.savefig('paper_plots/h_vs_assembly_time.png', dpi=dpi)
 plt.close()

--- a/examples/hemispherical_crater/run_example.sh
+++ b/examples/hemispherical_crater/run_example.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# The compression tolerance
+TOL=1e-2
+
+# Collect statistics for the "groundtruth form factor matrix"
+# (i.e. the original sparse form factor matrix without compression
+# applied)
+./collect_ingersoll_gt_stats.sh
+
+# Collect statistics for our method (the compressed form factor
+# matrix)
+./collect_ingersoll_stats.sh $TOL
+
+# Make plots from the collected statistics
+mkdir paper_plots
+./make_paper_plots

--- a/src/flux/compressed_form_factors.py
+++ b/src/flux/compressed_form_factors.py
@@ -625,8 +625,8 @@ class FormFactorPartitionBlock(FormFactorBlockMatrix):
                 spmat = get_form_factor_matrix(shape_model, I, J)
                 block = self.make_block(shape_model, I, J, spmat, is_diag,
                                         max_depth, force_max_depth)
-                row_blocks.append(block)
             blocks.append(row_blocks)
+                row_blocks.append(block)
         self._blocks = np.array(blocks, dtype=CompressedFormFactorBlock)
 
     def make_child_block(self, *args):

--- a/src/flux/compressed_form_factors.py
+++ b/src/flux/compressed_form_factors.py
@@ -598,8 +598,12 @@ class FormFactorOctreeBlock(FormFactor2dTreeBlock):
 
 class FormFactorPartitionBlock(FormFactorBlockMatrix):
 
-    def __init__(self, root, shape_model, parts,
+    def __init__(self, root, shape_model, parts=None,
+                 max_depth=None, force_max_depth=False,
                  ChildBlock=FormFactorQuadtreeBlock):
+        if parts is None:
+            parts = [np.range(shape_model.num_faces)]
+
         I_union = []
         for I in parts:
             I_union = np.union1d(I_union, I)
@@ -619,7 +623,8 @@ class FormFactorPartitionBlock(FormFactorBlockMatrix):
             for j, J in enumerate(parts):
                 is_diag = i == j
                 spmat = get_form_factor_matrix(shape_model, I, J)
-                block = self.make_block(shape_model, I, J, spmat, is_diag)
+                block = self.make_block(shape_model, I, J, spmat, is_diag,
+                                        max_depth, force_max_depth)
                 row_blocks.append(block)
             blocks.append(row_blocks)
         self._blocks = np.array(blocks, dtype=CompressedFormFactorBlock)


### PR DESCRIPTION
@steo85it @nschorgh

Here is the start of the "hemisphere example" (i.e. bowl-shaped crater).

Please take a quick look at this and then I will merge into master, at which point it can be run on a cluster somewhere.

In the two `collect_ingersoll_*.sh` scripts, the `$p` variable controls the fineness of the mesh. The larger the value, the finer the triangle mesh. I ran this for `p = 4, ..., 10` and got the following plots:

![h_vs_assembly_time](https://user-images.githubusercontent.com/6035363/149377839-c34f2d57-7310-4df4-954e-201bd14c40cd.png)
![h_vs_B_and_E_time](https://user-images.githubusercontent.com/6035363/149377865-06d67e48-96ce-4985-bfae-28d747d74b06.png)
![h_vs_rms](https://user-images.githubusercontent.com/6035363/149377875-d292d7d9-227d-49fc-a17a-4b99915d9f81.png)
![h_vs_size](https://user-images.githubusercontent.com/6035363/149377883-f815941a-2221-46f4-839a-a314a8179727.png)
![h_vs_T_time](https://user-images.githubusercontent.com/6035363/149377891-981865f7-3f40-4b29-bd4a-85f7c03da3d5.png)

Here's the output when running `collect_ingersoll_stats.sh`:

```
p = 4
- groundtruth temperature in shadow: 148.86 K
- created tri. mesh with 244 faces
- wrote ingersoll.obj
- finished assembly (0.1 Mb) [0.60 s]
- wrote FF.bin
- computed direct irradiance [0.00 s]
- wrote E.png to disk
- computed radiosity [0.00 s]
- wrote B.png
- computed T [0.00 s]
- wrote T.png
- wrote error.png
- max error: 4.74 K
- RMS error: 1.47 K
- wrote stats.json

real	0m2.586s
user	0m8.008s
sys	0m0.415s

p = 5
- groundtruth temperature in shadow: 148.86 K
- created tri. mesh with 525 faces
- wrote ingersoll.obj
- finished assembly (0.2 Mb) [1.08 s]
- wrote FF.bin
- computed direct irradiance [0.00 s]
- wrote E.png to disk
- computed radiosity [0.01 s]
- wrote B.png
- computed T [0.01 s]
- wrote T.png
- wrote error.png
- max error: 2.70 K
- RMS error: 0.88 K
- wrote stats.json

real	0m2.667s
user	0m13.451s
sys	0m0.461s

p = 6
- groundtruth temperature in shadow: 148.86 K
- created tri. mesh with 1215 faces
- wrote ingersoll.obj
- finished assembly (0.8 Mb) [4.12 s]
- wrote FF.bin
- computed direct irradiance [0.00 s]
- wrote E.png to disk
- computed radiosity [0.01 s]
- wrote B.png
- computed T [0.01 s]
- wrote T.png
- wrote error.png
- max error: 2.23 K
- RMS error: 0.63 K
- wrote stats.json

real	0m5.808s
user	0m52.919s
sys	0m0.867s

p = 7
- groundtruth temperature in shadow: 148.86 K
- created tri. mesh with 2713 faces
- wrote ingersoll.obj
- finished assembly (1.5 Mb) [13.74 s]
- wrote FF.bin
- computed direct irradiance [0.01 s]
- wrote E.png to disk
- computed radiosity [0.01 s]
- wrote B.png
- computed T [0.03 s]
- wrote T.png
- wrote error.png
- max error: 1.70 K
- RMS error: 0.45 K
- wrote stats.json

real	0m15.505s
user	3m5.363s
sys	0m2.132s

p = 8
- groundtruth temperature in shadow: 148.86 K
- created tri. mesh with 6089 faces
- wrote ingersoll.obj
- finished assembly (4.4 Mb) [62.58 s]
- wrote FF.bin
- computed direct irradiance [0.02 s]
- wrote E.png to disk
- computed radiosity [0.03 s]
- wrote B.png
- computed T [0.09 s]
- wrote T.png
- wrote error.png
- max error: 1.27 K
- RMS error: 0.33 K
- wrote stats.json

real	1m4.763s
user	12m38.506s
sys	0m6.771s

p = 9
- groundtruth temperature in shadow: 148.86 K
- created tri. mesh with 13769 faces
- wrote ingersoll.obj
- finished assembly (11.9 Mb) [305.83 s]
- wrote FF.bin
- computed direct irradiance [0.03 s]
- wrote E.png to disk
- computed radiosity [0.04 s]
- wrote B.png
- computed T [0.12 s]
- wrote T.png
- wrote error.png
- max error: 1.01 K
- RMS error: 0.24 K
- wrote stats.json

real	5m8.230s
user	37m18.598s
sys	0m16.454s

p = 10
- groundtruth temperature in shadow: 148.86 K
- created tri. mesh with 30919 faces
- wrote ingersoll.obj
- finished assembly (33.6 Mb) [1610.97 s]
- wrote FF.bin
- computed direct irradiance [0.09 s]
- wrote E.png to disk
- computed radiosity [0.18 s]
- wrote B.png
- computed T [0.54 s]
- wrote T.png
- wrote error.png
- max error: 0.82 K
- RMS error: 0.19 K
- wrote stats.json

real	26m54.641s
user	122m6.081s
sys	0m41.162s
```

and the output of running `collect_ingersoll_gt_stats.sh`:

```
p = 4
- groundtruth temperature in shadow: 148.86 K
- created tri. mesh with 244 faces
- wrote ingersoll.obj
- tol argument not passed: assembling sparse form factor matrix
- finished assembly (0.1 Mb) [0.16 s]
- wrote FF.npz
- computed direct irradiance [0.00 s]
- wrote E.png to disk
- computed radiosity [0.00 s]
- wrote B.png
- computed T [0.00 s]
- wrote T.png
- wrote error.png
- max error: 4.74 K
- RMS error: 1.47 K
- wrote stats.json

real	0m1.814s
user	0m3.632s
sys	0m0.194s

p = 5
- groundtruth temperature in shadow: 148.86 K
- created tri. mesh with 525 faces
- wrote ingersoll.obj
- tol argument not passed: assembling sparse form factor matrix
- finished assembly (0.6 Mb) [0.59 s]
- wrote FF.npz
- computed direct irradiance [0.00 s]
- wrote E.png to disk
- computed radiosity [0.00 s]
- wrote B.png
- computed T [0.00 s]
- wrote T.png
- wrote error.png
- max error: 2.69 K
- RMS error: 0.87 K
- wrote stats.json

real	0m2.296s
user	0m9.408s
sys	0m0.305s

p = 6
- groundtruth temperature in shadow: 148.86 K
- created tri. mesh with 1215 faces
- wrote ingersoll.obj
- tol argument not passed: assembling sparse form factor matrix
- finished assembly (2.8 Mb) [2.42 s]
- wrote FF.npz
- computed direct irradiance [0.00 s]
- wrote E.png to disk
- computed radiosity [0.00 s]
- wrote B.png
- computed T [0.00 s]
- wrote T.png
- wrote error.png
- max error: 2.12 K
- RMS error: 0.65 K
- wrote stats.json

real	0m4.237s
user	0m36.584s
sys	0m0.441s

p = 7
- groundtruth temperature in shadow: 148.86 K
- created tri. mesh with 2713 faces
- wrote ingersoll.obj
- tol argument not passed: assembling sparse form factor matrix
- finished assembly (13.5 Mb) [11.46 s]
- wrote FF.npz
- computed direct irradiance [0.01 s]
- wrote E.png to disk
- computed radiosity [0.01 s]
- wrote B.png
- computed T [0.02 s]
- wrote T.png
- wrote error.png
- max error: 1.76 K
- RMS error: 0.46 K
- wrote stats.json

real	0m13.599s
user	2m51.475s
sys	0m0.958s

p = 8
- groundtruth temperature in shadow: 148.86 K
- created tri. mesh with 6089 faces
- wrote ingersoll.obj
- tol argument not passed: assembling sparse form factor matrix
- finished assembly (71.0 Mb) [54.14 s]
- wrote FF.npz
- computed direct irradiance [0.02 s]
- wrote E.png to disk
- computed radiosity [0.03 s]
- wrote B.png
- computed T [0.10 s]
- wrote T.png
- wrote error.png
- max error: 1.43 K
- RMS error: 0.34 K
- wrote stats.json

real	0m57.981s
user	7m2.509s
sys	0m3.499s

p = 9
- groundtruth temperature in shadow: 148.86 K
- created tri. mesh with 13769 faces
- wrote ingersoll.obj
- tol argument not passed: assembling sparse form factor matrix
- finished assembly (358.2 Mb) [258.76 s]
- wrote FF.npz
- computed direct irradiance [0.04 s]
- wrote E.png to disk
- computed radiosity [0.16 s]
- wrote B.png
- computed T [0.47 s]
- wrote T.png
- wrote error.png
- max error: 0.98 K
- RMS error: 0.24 K
- wrote stats.json

real	4m30.146s
user	21m33.088s
sys	0m7.933s

p = 10
- groundtruth temperature in shadow: 148.86 K
- created tri. mesh with 30919 faces
- wrote ingersoll.obj
- tol argument not passed: assembling sparse form factor matrix
- finished assembly (1836.2 Mb) [1381.31 s]
- wrote FF.npz
- computed direct irradiance [0.09 s]
- wrote E.png to disk
- computed radiosity [0.81 s]
- wrote B.png
- computed T [2.44 s]
- wrote T.png
- wrote error.png
- max error: 0.77 K
- RMS error: 0.19 K
- wrote stats.json

real	24m59.433s
user	71m37.929s
sys	0m18.806s
```
